### PR TITLE
fix(): upgrade typedoc from v0.19 to v0.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     branches:
     - master
     - next
+    - renovate/*
 
 jobs:
   build:

--- a/packages/build-config-factory/package.json
+++ b/packages/build-config-factory/package.json
@@ -32,6 +32,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "typedoc": "^0.20.20",
+    "typedoc019": "npm:typedoc@^0.19.2",
     "typedoc-plugin-no-inherit": "^1.2.0"
   }
 }

--- a/packages/build-config-factory/package.json
+++ b/packages/build-config-factory/package.json
@@ -31,7 +31,7 @@
     "npmlog": "^4.1.2",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.20.20",
     "typedoc-plugin-no-inherit": "^1.2.0"
   }
 }

--- a/packages/build-config-factory/src/generateBrickDocs.js
+++ b/packages/build-config-factory/src/generateBrickDocs.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const rimraf = require("rimraf");
-const TypeDoc = require("typedoc");
+const TypeDoc = require("typedoc019");
 const { get } = require("lodash");
 const log = require("npmlog");
 const brickKindMap = {

--- a/packages/build-config-factory/src/generateProviderDocs.js
+++ b/packages/build-config-factory/src/generateProviderDocs.js
@@ -1,37 +1,35 @@
 const path = require("path");
+const fs = require("fs-extra");
 const TypeDoc = require("typedoc");
 
-module.exports = function generateProviderDocs(packageName) {
+module.exports = async function generateProviderDocs(packageName) {
   const app = new TypeDoc.Application();
   const providersJson = require(path.resolve("providers.json"));
 
+  app.options.addReader(new TypeDoc.TSConfigReader());
+
+  const tsconfigFilename = "tsconfig.providerDocs.json";
+  const tsconfigPath = path.resolve(tsconfigFilename);
+
+  fs.copyFileSync(path.join(__dirname, tsconfigFilename), tsconfigPath);
+
   app.bootstrap({
-    // tsconfig
-    module: "ESNext",
-    target: "ESNext",
-    moduleResolution: "node",
-    skipLibCheck: true,
-    esModuleInterop: true,
-    experimentalDecorators: true,
-
-    // typedoc config
+    tsconfig: tsconfigPath,
+    // tsconfig: path.resolve("../../tsconfig.providerDocs.json"),
     excludeExternals: true,
-    excludeNotExported: true,
-    includeDeclarations: true
-  });
-
-  const project = app.convert(
-    app.expandInputFiles([
+    entryPoints: [
       path.dirname(
         require.resolve(`${providersJson.sdk}/dist/types/index.d.ts`, {
-          paths: [process.cwd()]
+          paths: [process.cwd()],
         })
-      )
-    ])
-  );
+      ),
+    ],
+  });
+
+  const project = app.convert();
 
   if (project) {
-    app.generateJson(project, path.resolve(`dist/docs.json`));
+    await app.generateJson(project, path.resolve(`dist/docs.json`));
     console.log(`Providers docs for ${packageName} generated.`);
   } else {
     throw new Error(`typedoc convert failed for ${packageName}`);

--- a/packages/build-config-factory/src/post-build.js
+++ b/packages/build-config-factory/src/post-build.js
@@ -187,7 +187,7 @@ const mergeEditors = () => {
   }
 };
 
-module.exports = (scope) => {
+async function postBuild(scope) {
   const cwd = process.cwd();
   const pluginName = path.basename(cwd);
   const templateRoot = path.join(__dirname, "../template");
@@ -199,7 +199,7 @@ module.exports = (scope) => {
   if (scope === "bricks") {
     generateContracts();
     if (pluginName.startsWith(providerPackagePrefix)) {
-      generateProviderDocs(pluginName);
+      await generateProviderDocs(pluginName);
     } else {
       enableGenerateDoc && generateBrickDocs(pluginName, scope);
     }
@@ -212,4 +212,8 @@ module.exports = (scope) => {
   } else if (scope === "templates") {
     generateDeps();
   }
+}
+
+module.exports = (scope) => {
+  postBuild(scope).catch(console.error);
 };

--- a/packages/build-config-factory/src/tsconfig.providerDocs.json
+++ b/packages/build-config-factory/src/tsconfig.providerDocs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5162,7 +5162,7 @@ colorette@^1.1.0, colorette@^1.2.1:
   resolved "https://registry.npm.taobao.org/colorette/download/colorette-1.2.1.tgz?cache=0&sync_timestamp=1593955763917&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcolorette%2Fdownload%2Fcolorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha1-TQuSEyXBT6+SYzCGpTbbbolWSxs=
 
-colors@^1.1.2, colors@^1.2.1:
+colors@^1.1.2, colors@^1.2.1, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npm.taobao.org/colors/download/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha1-xQSRR51MG9rtLJztMs98fcI2D3g=
@@ -8055,11 +8055,6 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.npm.taobao.org/hex-color-regex/download/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=
 
-highlight.js@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.npm.taobao.org/highlight.js/download/highlight.js-10.2.0.tgz#367151bcf813adebc54822f1cb51d2e1e599619f"
-  integrity sha1-NnFRvPgTrevFSCLxy1HS4eWZYZ8=
-
 history@^4.10.1:
   version "4.10.1"
   resolved "https://registry.npm.taobao.org/history/download/history-4.10.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhistory%2Fdownload%2Fhistory-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -10250,10 +10245,10 @@ marked@^0.7.0:
   resolved "https://registry.npm.taobao.org/marked/download/marked-0.7.0.tgz?cache=0&sync_timestamp=1562386991938&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmarked%2Fdownload%2Fmarked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha1-tkIB8FHScbHtwQoE0a6bdLuOXA4=
 
-marked@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npm.taobao.org/marked/download/marked-1.1.1.tgz?cache=0&sync_timestamp=1594690314435&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmarked%2Fdownload%2Fmarked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
-  integrity sha1-5dYbaYQiENXfV7BYVuDJFXJwPmo=
+marked@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.npm.taobao.org/marked/download/marked-1.2.8.tgz?cache=0&sync_timestamp=1611686349234&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmarked%2Fdownload%2Fmarked-1.2.8.tgz#5008ece15cfa43e653e85845f3525af4beb6bdd4"
+  integrity sha1-UAjs4Vz6Q+ZT6FhF81Ja9L62vdQ=
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -11144,6 +11139,13 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=
   dependencies:
     mimic-fn "^2.1.0"
+
+onigasm@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.npm.taobao.org/onigasm/download/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
+  integrity sha1-zE0qeaD6C2TK7B9MfqNnWFpnaJI=
+  dependencies:
+    lru-cache "^5.1.1"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -14111,6 +14113,31 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
+shiki-languages@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.npm.taobao.org/shiki-languages/download/shiki-languages-0.2.7.tgz#7230b675b96d37a36ac1bf995525375ce69f3924"
+  integrity sha1-cjC2dbltN6Nqwb+ZVSU3XOafOSQ=
+  dependencies:
+    vscode-textmate "^5.2.0"
+
+shiki-themes@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.npm.taobao.org/shiki-themes/download/shiki-themes-0.2.7.tgz#6e04451d832152e0fc969876a7bd926b3963c1f2"
+  integrity sha1-bgRFHYMhUuD8lph2p72SazljwfI=
+  dependencies:
+    json5 "^2.1.0"
+    vscode-textmate "^5.2.0"
+
+shiki@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.npm.taobao.org/shiki/download/shiki-0.2.7.tgz#d2547548ed8742673730e1e4bbe792a77c445540"
+  integrity sha1-0lR1SO2HQmc3MOHku+eSp3xEVUA=
+  dependencies:
+    onigasm "^2.2.5"
+    shiki-languages "^0.2.7"
+    shiki-themes "^0.2.7"
+    vscode-textmate "^5.2.0"
+
 side-channel@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npm.taobao.org/side-channel/download/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"
@@ -15264,32 +15291,32 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typedoc-default-themes@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.npm.taobao.org/typedoc-default-themes/download/typedoc-default-themes-0.11.4.tgz?cache=0&sync_timestamp=1600653832744&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftypedoc-default-themes%2Fdownload%2Ftypedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
-  integrity sha1-G8VbfI0RMoRGFv9vVw4eLNDrc0M=
+typedoc-default-themes@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.npm.taobao.org/typedoc-default-themes/download/typedoc-default-themes-0.12.7.tgz#d44f68d40a3e90a19b5ea7be4cc6ed949afe768d"
+  integrity sha1-1E9o1Ao+kKGbXqe+TMbtlJr+do0=
 
 typedoc-plugin-no-inherit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npm.taobao.org/typedoc-plugin-no-inherit/download/typedoc-plugin-no-inherit-1.2.0.tgz#7f73809c04cb29c03afe5eea356534968cb717a9"
   integrity sha1-f3OAnATLKcA6/l7qNWU0loy3F6k=
 
-typedoc@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.npm.taobao.org/typedoc/download/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
-  integrity sha1-hCpjpYH0kg92sDRruA6ypJr8LCg=
+typedoc@^0.20.20:
+  version "0.20.20"
+  resolved "https://registry.npm.taobao.org/typedoc/download/typedoc-0.20.20.tgz#0f0915fb73e7371fc2cf8c74b6a3207dcf5c3dda"
+  integrity sha1-DwkV+3PnNx/Cz4x0tqMgfc9cPdo=
   dependencies:
-    fs-extra "^9.0.1"
+    colors "^1.4.0"
+    fs-extra "^9.1.0"
     handlebars "^4.7.6"
-    highlight.js "^10.2.0"
     lodash "^4.17.20"
     lunr "^2.3.9"
-    marked "^1.1.1"
+    marked "^1.2.8"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    semver "^7.3.2"
     shelljs "^0.8.4"
-    typedoc-default-themes "^0.11.4"
+    shiki "^0.2.7"
+    typedoc-default-themes "^0.12.7"
 
 typescript-json-schema@^0.48.0:
   version "0.48.0"
@@ -15606,6 +15633,11 @@ void-elements@^2.0.1:
   version "2.0.1"
   resolved "http://registry.npm.taobao.org/void-elements/download/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
+
+vscode-textmate@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npm.taobao.org/vscode-textmate/download/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha1-AfAXYKOR6CIv5PM/vMvRrXGu104=
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8055,6 +8055,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.npm.taobao.org/hex-color-regex/download/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=
 
+highlight.js@^10.2.0:
+  version "10.5.0"
+  resolved "https://registry.npm.taobao.org/highlight.js/download/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
+  integrity sha1-Pwn+3mqGV1c3jy2evcvBW6Jo+Y8=
+
 history@^4.10.1:
   version "4.10.1"
   resolved "https://registry.npm.taobao.org/history/download/history-4.10.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhistory%2Fdownload%2Fhistory-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -10245,7 +10250,7 @@ marked@^0.7.0:
   resolved "https://registry.npm.taobao.org/marked/download/marked-0.7.0.tgz?cache=0&sync_timestamp=1562386991938&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmarked%2Fdownload%2Fmarked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha1-tkIB8FHScbHtwQoE0a6bdLuOXA4=
 
-marked@^1.2.8:
+marked@^1.1.1, marked@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npm.taobao.org/marked/download/marked-1.2.8.tgz?cache=0&sync_timestamp=1611686349234&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmarked%2Fdownload%2Fmarked-1.2.8.tgz#5008ece15cfa43e653e85845f3525af4beb6bdd4"
   integrity sha1-UAjs4Vz6Q+ZT6FhF81Ja9L62vdQ=
@@ -15291,6 +15296,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typedoc-default-themes@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.npm.taobao.org/typedoc-default-themes/download/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
+  integrity sha1-G8VbfI0RMoRGFv9vVw4eLNDrc0M=
+
 typedoc-default-themes@^0.12.7:
   version "0.12.7"
   resolved "https://registry.npm.taobao.org/typedoc-default-themes/download/typedoc-default-themes-0.12.7.tgz#d44f68d40a3e90a19b5ea7be4cc6ed949afe768d"
@@ -15300,6 +15310,23 @@ typedoc-plugin-no-inherit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npm.taobao.org/typedoc-plugin-no-inherit/download/typedoc-plugin-no-inherit-1.2.0.tgz#7f73809c04cb29c03afe5eea356534968cb717a9"
   integrity sha1-f3OAnATLKcA6/l7qNWU0loy3F6k=
+
+"typedoc019@npm:typedoc@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.npm.taobao.org/typedoc/download/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
+  integrity sha1-hCpjpYH0kg92sDRruA6ypJr8LCg=
+  dependencies:
+    fs-extra "^9.0.1"
+    handlebars "^4.7.6"
+    highlight.js "^10.2.0"
+    lodash "^4.17.20"
+    lunr "^2.3.9"
+    marked "^1.1.1"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    semver "^7.3.2"
+    shelljs "^0.8.4"
+    typedoc-default-themes "^0.11.4"
 
 typedoc@^0.20.20:
   version "0.20.20"


### PR DESCRIPTION
TypeDoc 从 v0.19.x 到 v0.20.x 包含破坏性变更。同时只有最新的 TypeDoc 支持最新的 TypeScript，为了避免以后代码中使用了最新的 TypeScript 才支持的语法时，TypeDoc 无法工作，因此有必要尽快升级 TypeDoc 的用法。

生成 Provider 文档的脚本我已更新使用 v0.20 并做好了向后兼容处理。

另一方面，生成构件文档的脚本没有更新，并且由于和前者在同一个仓库，因此我暂时在对应的 package.json 中使用了 npm [包别名](https://docs.npmjs.com/cli/v6/commands/npm-install)：

```yaml
    "typedoc": "^0.20.20"
    "typedoc019": "npm:typedoc@^0.19.2"
```

构件文档的脚本暂时使用了 `typedoc019`。请 @WHChen-Alex 继续跟进这部分的升级。