### PR TITLE
feat(): update useBrick if condition, and support widget to expand

### DIFF
--- a/packages/brick-kit/src/BrickAsComponent.tsx
+++ b/packages/brick-kit/src/BrickAsComponent.tsx
@@ -264,6 +264,13 @@ export const SingleBrickAsComponent = React.memo(
       } else if (
         !looseCheckIfByTransform(useBrick, data, {
           allowInject: true,
+          // useBrick 中嵌套custom-template的情况下, 会存在丢失getTplVariables的情况, 因此需要在此进行补充
+          getTplVariables: () =>
+            tplContext.getContext(
+              (useBrick as RuntimeBrickConfWithTplSymbols)[
+                symbolForTplContextId
+              ]
+            ),
         })
       ) {
         return false;

--- a/packages/brick-kit/src/checkIf.ts
+++ b/packages/brick-kit/src/checkIf.ts
@@ -97,6 +97,7 @@ export function looseCheckIfByTransform(
   data: unknown,
   options?: {
     allowInject?: boolean;
+    getTplVariables?: () => Record<string, unknown>;
   }
 ): boolean {
   return (

--- a/packages/brick-types/src/story.ts
+++ b/packages/brick-types/src/story.ts
@@ -1,3 +1,4 @@
+import { BuilderCustomTemplateNode, LayerType } from "./builder";
 import { BrickConf, I18nData } from "./manifest";
 import { MenuIcon } from "./menu";
 
@@ -41,6 +42,8 @@ export interface Story {
   icon?: MenuIcon;
   previewColumns?: number;
   author?: string;
+  layerType?: LayerType;
+  originData?: BuilderCustomTemplateNode;
 }
 
 /** @internal */

--- a/packages/editor-bricks-helper/src/internal/BuilderDataManager.ts
+++ b/packages/editor-bricks-helper/src/internal/BuilderDataManager.ts
@@ -170,7 +170,12 @@ export class BuilderDataManager implements AbstractBuilderDataManager {
     const rootId = getUniqueNodeId();
     const newData = {
       rootId,
-      ...getAppendingNodesAndEdges(root, rootId, templateSourceMap),
+      ...getAppendingNodesAndEdges(
+        root,
+        rootId,
+        templateSourceMap,
+        this.storyList
+      ),
     };
     this.data = {
       ...newData,
@@ -202,7 +207,8 @@ export class BuilderDataManager implements AbstractBuilderDataManager {
           "parent",
         ]) as Partial<BuilderRouteOrBrickNode> as BuilderRouteOrBrickNode,
         nodeUid,
-        this.templateSourceMap
+        this.templateSourceMap,
+        this.storyList
       );
 
     const newNodes = nodes.concat(appendingNodes);
@@ -268,7 +274,8 @@ export class BuilderDataManager implements AbstractBuilderDataManager {
             "parent",
           ]) as Partial<BuilderRouteOrBrickNode> as BuilderRouteOrBrickNode,
           nodeUid,
-          this.templateSourceMap
+          this.templateSourceMap,
+          this.storyList
         );
       newNodes.push(...appendingNodes);
       newEdges.push(

--- a/packages/editor-bricks-helper/src/internal/getAppendingNodesAndEdges.ts
+++ b/packages/editor-bricks-helper/src/internal/getAppendingNodesAndEdges.ts
@@ -5,6 +5,7 @@ import {
   BuilderCustomTemplateNode,
   CustomTemplateProxyProperty,
   CustomTemplateProxyBasicProperty,
+  Story,
 } from "@next-core/brick-types";
 import { BuilderRuntimeEdge, BuilderRuntimeNode } from "../interfaces";
 import { getBuilderNode } from "./getBuilderNode";
@@ -14,7 +15,8 @@ import { isBrickNode } from "../assertions";
 export function getAppendingNodesAndEdges(
   nodeData: BuilderRouteOrBrickNode,
   nodeUid: number,
-  templateSourceMap: Map<string, BuilderCustomTemplateNode>
+  templateSourceMap: Map<string, BuilderCustomTemplateNode>,
+  storyList: Story[] = []
 ): {
   nodes: BuilderRuntimeNode[];
   edges: BuilderRuntimeEdge[];
@@ -43,11 +45,15 @@ export function getAppendingNodesAndEdges(
 
     if (
       isBrickNode(builderNode) &&
-      !builderNode.brick.includes(".") &&
-      builderNode.brick.startsWith("tpl-") &&
-      !processedTemplateSet.has(builderNode.brick) &&
-      (templateSource = templateSourceMap?.get(builderNode.brick)) &&
-      templateSource.children?.length > 0
+      ((!builderNode.brick.includes(".") &&
+        builderNode.brick.startsWith("tpl-") &&
+        !processedTemplateSet.has(builderNode.brick) &&
+        (templateSource = templateSourceMap?.get(builderNode.brick)) &&
+        templateSource.children?.length > 0) ||
+        ((templateSource = storyList.find(
+          (item) => item.storyId === builderNode.brick
+        )?.originData) &&
+          templateSource.children?.length > 0))
     ) {
       // Avoid nesting the same templates.
       processedTemplateSet.add(builderNode.brick);


### PR DESCRIPTION
Refs: NEXT_BUILDER-1017

## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查

Git 提交信息将决定包的版本发布及自动生成的 CHANGELOG，请检查工作内容与提交信息是否相符，并在以下每组选项中都依次确认。

> 破坏性变更是针对于下游使用者而言，可以通过本次改动对下游使用者的影响来识别变更类型：
>
> - 下游使用者不做任何改动，仍可以正常工作时，那么它属于普通变更。
> - 反之，下游使用者不做改动就无法正常工作时，那么它属于破坏性变更。
>
> 例如，构件修改了一个属性名，小产品 Storyboard 中需要使用新属性名才能工作，那么它就是破坏性变更。
> 又例如，构件还没有任何下游使用者，那么它的任何变更都是普通变更。

### 破坏性变更：

- [ ] ⚠️ 本次 MR 包含**破坏性变更**的提交，请继续确认以下所有选项：
- [ ] 没有更好的兼容方案，必须做破坏性变更。
- [ ] 使用了 `feat` 作为提交类型。
- [ ] 标注了 `BREAKING CHANGE: 你的变更说明`。
- [ ] 同时更新了本仓库中所有下游使用者的调用。
- [ ] 同时更新了本仓库中所有下游使用者对该子包的依赖为即将发布的 major 版本。
- [ ] 同时为其它仓库的 Migrating 做好了准备，例如文档或批量改动的方法。
- [ ] 手动验证过破坏性变更在 Migrate 后可以正常工作。
- [ ] 破坏性变更所在的提交没有意外携带其它子包的改动。

### 新特性：

- [x] 本次 MR 包含新特性的提交，且该提交不带有破坏性变更，并使用了 `feat` 作为提交类型。
- [ ] 给新特性添加了单元测试。
- [ ] 手动验证过新特性可以正常工作。

### 问题修复：

- [ ] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [ ] 给问题修复添加了单元测试。
- [ ] 手动验证过问题修复得到解决。

### 杂项工作：

即所有对下游使用者无任何影响、且没有必要显示在 CHANGELOG 中的改动，例如修改注释、测试用例、开发文档等：

- [ ] 本次 MR 包含杂项工作的提交，且该提交不带有问题修复、新特性或破坏性变更，并使用了 `chore`, `docs`, `test` 等作为提交类型。

<!-- ## 简单描述 !-->
1. widget构件使用 stories.json上的数据进行展开
2. useBrick if判断更新, 由于在useBrick中嵌套使用custom-template, 底层的会丢失getTplVariable, 导致if判断失败, 示例地址如下:
http://192.168.100.162/next/easyops-builtin-widgets/card-list-widget-review
if: <% TPL.picture %> 在tpl 单层嵌套时使用并无出现问题, 但是当嵌套出现两层, 改逻辑判断将失效
<!-- 我在这个 MR 里都做了哪些工作？!-->

<!-- ## Todo

<!-- 我还有哪些事情没做？!-->
