### PR TITLE
fix(): 修复直接使用契约时，还需要手动 build & push 问题

### DIFF
--- a/etc/brick-kit.api.md
+++ b/etc/brick-kit.api.md
@@ -248,6 +248,7 @@ export const developHelper: {
     updateTemplatePreviewSettings: typeof _dev_only_updateTemplatePreviewSettings;
     updateSnippetPreviewSettings: typeof _dev_only_updateSnippetPreviewSettings;
     updateFormPreviewSettings: typeof _dev_only_updateFormPreviewSettings;
+    getAddedContracts: typeof _dev_only_getAddedContracts;
     getContextValue: typeof _dev_only_getContextValue;
     getAllContextValues: typeof _dev_only_getAllContextValues;
     render: typeof _dev_only_render;
@@ -458,6 +459,21 @@ export type PartialMicroApp = Pick<MicroApp, "id" | "isBuildPush">;
 //
 // @internal (undocumented)
 export function preprocessTransformProperties(data: unknown, to: GeneralTransform, from?: string | string[], mapArray?: boolean | "auto", options?: TransformOptions): Record<string, unknown>;
+
+// @public (undocumented)
+export interface PreviewOption {
+    // (undocumented)
+    appId?: string;
+    // (undocumented)
+    formId?: string;
+    // (undocumented)
+    updateStoryboardType?: "route" | "template" | "snippet" | "form";
+}
+
+// Warning: (ae-forgotten-export) The symbol "FormDataProperties" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type PreviewStoryboardPatch = CustomTemplate | RouteConf | RuntimeSnippet | FormDataProperties;
 
 // @public
 export function property(options?: PropertyDeclaration): any;
@@ -684,25 +700,26 @@ export class WebsocketMessageResponse {
 
 // Warnings were encountered during analysis:
 //
-// src/developHelper.ts:31:3 - (ae-forgotten-export) The symbol "LocationContext" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:32:3 - (ae-forgotten-export) The symbol "mountTree" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:33:3 - (ae-forgotten-export) The symbol "unmountTree" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:34:3 - (ae-forgotten-export) The symbol "afterMountTree" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:35:3 - (ae-forgotten-export) The symbol "_dev_only_getBrickPackages" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:36:3 - (ae-forgotten-export) The symbol "_dev_only_getTemplatePackages" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:37:3 - (ae-forgotten-export) The symbol "_dev_only_getStoryboards" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:38:3 - (ae-forgotten-export) The symbol "_dev_only_loadEditorBricks" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:39:3 - (ae-forgotten-export) The symbol "_dev_only_loadDynamicBricksInBrickConf" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:40:3 - (ae-forgotten-export) The symbol "_dev_only_getFakeKernel" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:49:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboard" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:50:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboardByRoute" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:51:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboardByTemplate" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:52:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboardBySnippet" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:53:3 - (ae-forgotten-export) The symbol "_dev_only_updateTemplatePreviewSettings" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:54:3 - (ae-forgotten-export) The symbol "_dev_only_updateSnippetPreviewSettings" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:55:3 - (ae-forgotten-export) The symbol "_dev_only_updateFormPreviewSettings" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:56:3 - (ae-forgotten-export) The symbol "_dev_only_getContextValue" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:57:3 - (ae-forgotten-export) The symbol "_dev_only_getAllContextValues" needs to be exported by the entry point index.d.ts
-// src/developHelper.ts:58:3 - (ae-forgotten-export) The symbol "_dev_only_render" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:32:3 - (ae-forgotten-export) The symbol "LocationContext" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:33:3 - (ae-forgotten-export) The symbol "mountTree" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:34:3 - (ae-forgotten-export) The symbol "unmountTree" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:35:3 - (ae-forgotten-export) The symbol "afterMountTree" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:36:3 - (ae-forgotten-export) The symbol "_dev_only_getBrickPackages" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:37:3 - (ae-forgotten-export) The symbol "_dev_only_getTemplatePackages" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:38:3 - (ae-forgotten-export) The symbol "_dev_only_getStoryboards" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:39:3 - (ae-forgotten-export) The symbol "_dev_only_loadEditorBricks" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:40:3 - (ae-forgotten-export) The symbol "_dev_only_loadDynamicBricksInBrickConf" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:41:3 - (ae-forgotten-export) The symbol "_dev_only_getFakeKernel" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:50:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboard" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:51:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboardByRoute" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:52:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboardByTemplate" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:53:3 - (ae-forgotten-export) The symbol "_dev_only_updateStoryboardBySnippet" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:54:3 - (ae-forgotten-export) The symbol "_dev_only_updateTemplatePreviewSettings" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:55:3 - (ae-forgotten-export) The symbol "_dev_only_updateSnippetPreviewSettings" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:56:3 - (ae-forgotten-export) The symbol "_dev_only_updateFormPreviewSettings" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:57:3 - (ae-forgotten-export) The symbol "_dev_only_getAddedContracts" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:58:3 - (ae-forgotten-export) The symbol "_dev_only_getContextValue" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:59:3 - (ae-forgotten-export) The symbol "_dev_only_getAllContextValues" needs to be exported by the entry point index.d.ts
+// src/developHelper.ts:60:3 - (ae-forgotten-export) The symbol "_dev_only_render" needs to be exported by the entry point index.d.ts
 
 ```

--- a/packages/brick-kit/src/core/Runtime.ts
+++ b/packages/brick-kit/src/core/Runtime.ts
@@ -48,6 +48,8 @@ import {
   CustomApiDefinition,
   AbstractRuntime,
   DataValueOption,
+  PreviewStoryboardPatch,
+  PreviewOption,
 } from "./interfaces";
 import { getBasePath } from "../internal/getBasePath";
 import { getCurrentMode, getCurrentTheme } from "../themeAndMode";
@@ -164,6 +166,14 @@ export function _dev_only_updateStoryboardBySnippet(
   settings?: unknown
 ): void {
   kernel._dev_only_updateStoryboardBySnippet(appId, newSnippet, settings);
+}
+
+/* istanbul ignore next */
+export function _dev_only_getAddedContracts(
+  storyboardPatch: PreviewStoryboardPatch,
+  options: PreviewOption
+): string[] {
+  return kernel._dev_only_getAddedContracts(storyboardPatch, options);
 }
 
 /* istanbul ignore next */

--- a/packages/brick-kit/src/core/interfaces.ts
+++ b/packages/brick-kit/src/core/interfaces.ts
@@ -8,12 +8,16 @@ import {
   ExtField,
   ContractRequest,
   ContractResponse,
+  CustomTemplate,
+  RouteConf,
+  RuntimeSnippet,
 } from "@next-core/brick-types";
 import {
   ColorThemeOptionsByBrand,
   ColorThemeOptionsByBaseColors,
   ColorThemeOptionsByVariables,
 } from "../internal/applyColorTheme";
+import { FormDataProperties } from "./CustomForms/ExpandCustomForm";
 import { CustomProcessorFunc } from "./exports";
 import { LazyBrickImportFunction } from "./LazyBrickRegistry";
 
@@ -226,3 +230,15 @@ export interface ThemeSetting {
 export interface DataValueOption {
   tplContextId?: string;
 }
+
+export interface PreviewOption {
+  appId?: string;
+  formId?: string;
+  updateStoryboardType?: "route" | "template" | "snippet" | "form";
+}
+
+export type PreviewStoryboardPatch =
+  | CustomTemplate
+  | RouteConf
+  | RuntimeSnippet
+  | FormDataProperties;

--- a/packages/brick-kit/src/developHelper.ts
+++ b/packages/brick-kit/src/developHelper.ts
@@ -22,6 +22,7 @@ import {
   _dev_only_updateStoryboardByRoute,
   _dev_only_updateStoryboardByTemplate,
   _dev_only_updateStoryboardBySnippet,
+  _dev_only_getAddedContracts,
   _dev_only_render,
 } from "./core/exports";
 
@@ -53,6 +54,7 @@ export const developHelper = {
   updateTemplatePreviewSettings: _dev_only_updateTemplatePreviewSettings,
   updateSnippetPreviewSettings: _dev_only_updateSnippetPreviewSettings,
   updateFormPreviewSettings: _dev_only_updateFormPreviewSettings,
+  getAddedContracts: _dev_only_getAddedContracts,
   getContextValue: _dev_only_getContextValue,
   getAllContextValues: _dev_only_getAllContextValues,
   render: _dev_only_render,


### PR DESCRIPTION
Refs NEXT_BUILDER-3649

## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查

Git 提交信息将决定包的版本发布及自动生成的 CHANGELOG，请检查工作内容与提交信息是否相符，并在以下每组选项中都依次确认。

> 破坏性变更是针对于下游使用者而言，可以通过本次改动对下游使用者的影响来识别变更类型：
>
> - 下游使用者不做任何改动，仍可以正常工作时，那么它属于普通变更。
> - 反之，下游使用者不做改动就无法正常工作时，那么它属于破坏性变更。
>
> 例如，构件修改了一个属性名，小产品 Storyboard 中需要使用新属性名才能工作，那么它就是破坏性变更。
> 又例如，构件还没有任何下游使用者，那么它的任何变更都是普通变更。

### 破坏性变更：

- [ ] ⚠️ 本次 MR 包含**破坏性变更**的提交，请继续确认以下所有选项：
- [ ] 没有更好的兼容方案，必须做破坏性变更。
- [ ] 使用了 `feat` 作为提交类型。
- [ ] 标注了 `BREAKING CHANGE: 你的变更说明`。
- [ ] 同时更新了本仓库中所有下游使用者的调用。
- [ ] 同时更新了本仓库中所有下游使用者对该子包的依赖为即将发布的 major 版本。
- [ ] 同时为其它仓库的 Migrating 做好了准备，例如文档或批量改动的方法。
- [ ] 手动验证过破坏性变更在 Migrate 后可以正常工作。
- [ ] 破坏性变更所在的提交没有意外携带其它子包的改动。

### 新特性：

- [x] 本次 MR 包含新特性的提交，且该提交不带有破坏性变更，并使用了 `feat` 作为提交类型。
- [x] 给新特性添加了单元测试。
- [x] 手动验证过新特性可以正常工作。

### 问题修复：

- [ ] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [ ] 给问题修复添加了单元测试。
- [ ] 手动验证过问题修复得到解决。

### 杂项工作：

即所有对下游使用者无任何影响、且没有必要显示在 CHANGELOG 中的改动，例如修改注释、测试用例、开发文档等：

- [ ] 本次 MR 包含杂项工作的提交，且该提交不带有问题修复、新特性或破坏性变更，并使用了 `chore`, `docs`, `test` 等作为提交类型。

## 简单描述
### 当前现象：
当前在编排时直接使用契约预览环境会报错，需要通过手动 build & push 之后再刷新才能正常的显示，因为预览的时候没有对新增的契约做任何处理，所以会找不到该契约定义。
![image](https://github.com/easyops-cn/next-core/assets/24582340/5e784263-39e0-4a61-96ff-996c6f3c19f3)

### 解决方案
当编排保存的时候，会得到此次修改的内容节点信息，对于该信息的所形成的 storyboard 配置进行扫描，得到新增的契约部分，如果有新增契约的话自动调用 build & push 的操作，把新增的契约信息写进该小产品中

还有关联的另一个 PR
https://github.com/easyops-cn/next-basics/pull/2387

<!-- 我在这个 MR 里都做了哪些工作？!-->

<!-- ## Todo

<!-- 我还有哪些事情没做？!-->
